### PR TITLE
Add start page menu and creation pages

### DIFF
--- a/frontend/Anlegen.html
+++ b/frontend/Anlegen.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>Daten anlegen</title>
+  <style>
+    :root {
+      --bg: #f5f5f5;
+      --white: #fff;
+      --dark: #111;
+      --gray: #ccc;
+      --primary: #000;
+      --accent: #e82127;
+    }
+    body {
+      margin: 0;
+      padding: 40px 5vw;
+      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--dark);
+    }
+    h1 {
+      text-align: center;
+    }
+    form {
+      max-width: 600px;
+      margin: 0 auto 60px auto;
+      background: var(--white);
+      padding: 32px;
+      border-radius: 16px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.04);
+      display: grid;
+      grid-template-columns: 1fr 2fr;
+      gap: 16px 20px;
+    }
+    form label {
+      font-weight: 500;
+      align-self: center;
+    }
+    form input, form select {
+      padding: 10px;
+      border: 1px solid var(--gray);
+      border-radius: 8px;
+      font-size: 14px;
+      width: 100%;
+      box-sizing: border-box;
+      height: 40px;
+    }
+    form button {
+      grid-column: span 2;
+      background-color: var(--primary);
+      color: white;
+      border: none;
+      padding: 14px;
+      font-size: 15px;
+      border-radius: 10px;
+      cursor: pointer;
+      transition: background 0.3s ease;
+    }
+    form button:hover { background-color: #333; }
+    #menuToggle {
+      position: fixed;
+      top: 20px;
+      left: 20px;
+      font-size: 26px;
+      background: none;
+      border: none;
+      cursor: pointer;
+      z-index: 1000;
+    }
+    #sideMenu {
+      position: fixed;
+      top: 0; left: 0;
+      background: var(--white);
+      box-shadow: 2px 0 8px rgba(0,0,0,0.2);
+      padding: 60px 20px 20px 20px;
+      transform: translateX(-100%);
+      transition: transform 0.3s ease;
+      height: 100%;
+      z-index: 999;
+    }
+    #sideMenu.open { transform: translateX(0); }
+    #sideMenu ul { list-style: none; padding: 0; margin: 0; }
+    #sideMenu li { margin-bottom: 16px; }
+    #sideMenu a { color: var(--dark); text-decoration: none; font-weight: 600; }
+    .content-section { display: none; }
+    .content-section.active { display: block; }
+  </style>
+</head>
+<body>
+  <button id="menuToggle">&#9776;</button>
+  <nav id="sideMenu">
+    <ul>
+      <li><a href="Startseite.html">Startseite</a></li>
+      <li><a href="#" data-target="animalForm">Tier anlegen</a></li>
+      <li><a href="#" data-target="genusForm">Gattung anlegen</a></li>
+      <li><a href="#" data-target="locationForm">Ort anlegen</a></li>
+      <li><a href="#" data-target="observationForm">Beobachtung anlegen</a></li>
+    </ul>
+  </nav>
+
+  <div id="animalForm" class="content-section active">
+    <h1>Neues Tier anlegen</h1>
+    <form id="addAnimalForm">
+      <label>ID:</label>
+      <input type="number" name="id" min="1" required>
+      <label>Geschlecht:</label>
+      <select name="gender" id="genderSelect" required>
+        <option value="">Bitte wählen</option>
+        <option value="männlich">männlich</option>
+        <option value="weiblich">weiblich</option>
+      </select>
+      <label>Alter:</label>
+      <input type="number" name="estimatedAge" min="0" required>
+      <label>Gewicht:</label>
+      <input type="number" name="estimatedWeight" step="0.1" min="0" required>
+      <label>Größe:</label>
+      <input type="number" name="estimatedSize" step="0.1" min="0" required>
+      <label>Gattung:</label>
+      <select name="genusId" id="genusSelect" required>
+        <option value="">Bitte wählen</option>
+      </select>
+      <button type="submit">Hinzufügen</button>
+    </form>
+  </div>
+
+  <div id="genusForm" class="content-section">
+    <h1>Neue Gattung anlegen</h1>
+    <form id="addGenusForm">
+      <label>ID:</label>
+      <input type="number" name="id" min="1" required>
+      <label>Bezeichnung:</label>
+      <input type="text" name="designation" required>
+      <label>Lateinische Bezeichnung:</label>
+      <input type="text" name="latinDesignation" required>
+      <button type="submit">Hinzufügen</button>
+    </form>
+  </div>
+
+  <div id="locationForm" class="content-section">
+    <h1>Neuen Ort anlegen</h1>
+    <form id="addLocationForm">
+      <label>ID:</label>
+      <input type="number" name="id" min="1" required>
+      <label>Kurzbezeichnung:</label>
+      <input type="text" name="shortTitle" required>
+      <label>Beschreibung:</label>
+      <input type="text" name="description" required>
+      <button type="submit">Hinzufügen</button>
+    </form>
+  </div>
+
+  <div id="observationForm" class="content-section">
+    <h1>Neue Beobachtung anlegen</h1>
+    <form id="addObservedForm">
+      <label>Tier ID:</label>
+      <input type="number" name="animalId" min="1" required>
+      <label>Ort ID:</label>
+      <input type="number" name="locationId" min="1" required>
+      <label>Datum:</label>
+      <input type="date" name="date" required>
+      <label>Zeit:</label>
+      <input type="time" name="time" required>
+      <button type="submit">Hinzufügen</button>
+    </form>
+  </div>
+
+<script>
+const apiBase = 'http://localhost:8080';
+
+function loadGenusOptions() {
+  fetch(apiBase + '/genus')
+    .then(r => r.json())
+    .then(data => {
+      const sel = document.getElementById('genusSelect');
+      sel.innerHTML = '<option value="">Bitte wählen</option>';
+      data.forEach(g => {
+        const opt = document.createElement('option');
+        opt.value = g.id;
+        opt.textContent = `${g.designation} (${g.latinDesignation})`;
+        sel.appendChild(opt);
+      });
+    });
+}
+
+document.getElementById('addAnimalForm').addEventListener('submit', e => {
+  e.preventDefault();
+  const f = e.target;
+  const animal = {
+    id: parseInt(f.id.value),
+    gender: f.gender.value,
+    estimatedAge: parseInt(f.estimatedAge.value),
+    estimatedWeight: parseFloat(f.estimatedWeight.value),
+    estimatedSize: parseFloat(f.estimatedSize.value),
+    genus: { id: parseInt(f.genusId.value) }
+  };
+  fetch(apiBase + '/animal', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(animal)})
+    .then(() => f.reset());
+});
+
+document.getElementById('addGenusForm').addEventListener('submit', e => {
+  e.preventDefault();
+  const f = e.target;
+  const genus = { id: parseInt(f.id.value), designation: f.designation.value, latinDesignation: f.latinDesignation.value };
+  fetch(apiBase + '/genus', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(genus)})
+    .then(() => f.reset());
+});
+
+document.getElementById('addLocationForm').addEventListener('submit', e => {
+  e.preventDefault();
+  const f = e.target;
+  const loc = { id: parseInt(f.id.value), shortTitle: f.shortTitle.value, description: f.description.value };
+  fetch(apiBase + '/location', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(loc)})
+    .then(() => f.reset());
+});
+
+document.getElementById('addObservedForm').addEventListener('submit', e => {
+  e.preventDefault();
+  const f = e.target;
+  const obs = { animal: {id: parseInt(f.animalId.value)}, location: {id: parseInt(f.locationId.value)}, date: f.date.value, time: f.time.value };
+  fetch(apiBase + '/observed', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(obs)})
+    .then(() => f.reset());
+});
+
+loadGenusOptions();
+
+const menu = document.getElementById('sideMenu');
+document.getElementById('menuToggle').addEventListener('click', () => {
+  menu.classList.toggle('open');
+});
+document.querySelectorAll('#sideMenu a[data-target]').forEach(a => {
+  a.addEventListener('click', e => {
+    e.preventDefault();
+    document.querySelectorAll('.content-section').forEach(sec => sec.classList.remove('active'));
+    document.getElementById(a.dataset.target).classList.add('active');
+    menu.classList.remove('open');
+  });
+});
+</script>
+</body>
+</html>

--- a/frontend/Startseite.html
+++ b/frontend/Startseite.html
@@ -2,53 +2,36 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
-  <title>Willkommen</title>
+  <title>WildLifeObservation</title>
   <style>
     body {
       margin: 0;
-      padding: 0;
       font-family: Arial, sans-serif;
       background: url('startseite.png') no-repeat center center;
       background-size: cover;
-      height: 100vh;
-      position: relative;
+      min-height: 100vh;
       display: flex;
-      justify-content: center;
-      align-items: center;
       flex-direction: column;
+      align-items: center;
     }
-
-    .overlay {
-      position: absolute;
-      inset: 0;
-      background-color: rgba(255,255,255,0.3);
-      pointer-events: none;
-    }
-
+    #hero { height: 100vh; display:flex; flex-direction:column; justify-content:center; align-items:center; position:relative; }
+    .overlay { position: absolute; inset: 0; background-color: rgba(255,255,255,0.3); pointer-events:none; }
     .content {
-  background-color: rgba(255, 255, 255, 0.15);
-  padding: 40px;
-  border-radius: 16px;
-  backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 20px; /* Abstand zwischen Text & Button */
-  z-index: 2;
-}
-
-
-    h1 {
-      color: #2c3e50;
-      font-size: 40px;
-      margin-bottom: 30px;
+      background-color: rgba(255, 255, 255, 0.15);
+      padding: 40px;
+      border-radius: 16px;
+      backdrop-filter: blur(8px);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 20px;
+      z-index: 2;
     }
-
+    h1 { margin-bottom: 24px; }
     .btn {
-      position: relative;
       padding: 14px 32px;
       background-color: #6e9f44;
       color: white;
@@ -61,76 +44,126 @@
       cursor: pointer;
       text-decoration: none;
     }
-
-    .btn:hover {
-      transform: scale(1.05);
-      box-shadow: 0 8px 20px rgba(0,0,0,0.4);
-    }
-
-    .btn:hover::after {
-      content: ' 🐾';
-      opacity: 0.8;
-    }
-
-    .lang-toggle {
-      position: absolute;
-      top: 20px;
-      right: 30px;
-      color: white;
-      font-weight: bold;
-      font-size: 14px;
-      z-index: 3;
-    }
-
-    .lang-toggle a {
-      color: white;
-      text-decoration: none;
-      margin: 0 5px;
-      transition: color 0.2s;
-    }
-
-    .lang-toggle a:hover {
-      color: #ddd;
-    }
-    @keyframes blurOut {
-  0% {
-    filter: blur(0px);
-    opacity: 1;
-    transform: scale(1);
-  }
-  100% {
-    filter: blur(20px) brightness(60%);
-    opacity: 0;
-    transform: scale(0.97);
-  }
-}
-
-.blur-effect {
-  animation: blurOut 1s ease forwards;
-}
-
+    .btn:hover { transform: scale(1.05); box-shadow: 0 8px 20px rgba(0,0,0,0.4); }
+    .lang-toggle { position:absolute; top:20px; right:30px; color:white; font-weight:bold; font-size:14px; z-index:3; }
+    .lang-toggle a { color:white; text-decoration:none; margin:0 5px; }
+    #menuToggle { position: fixed; top: 20px; left: 20px; font-size:26px; background:none; border:none; cursor:pointer; z-index:1000; }
+    #sideMenu { position: fixed; top:0; left:0; background:white; box-shadow:2px 0 8px rgba(0,0,0,0.2); padding:60px 20px 20px 20px; transform:translateX(-100%); transition: transform 0.3s ease; height:100%; z-index:999; }
+    #sideMenu.open { transform: translateX(0); }
+    #sideMenu ul { list-style:none; padding:0; margin:0; }
+    #sideMenu li { margin-bottom:16px; }
+    #sideMenu a { color:#111; text-decoration:none; font-weight:600; }
+    table { width:100%; border-collapse:collapse; margin-bottom:40px; background:white; box-shadow:0 4px 10px rgba(0,0,0,0.05); border-radius:12px; overflow:hidden; }
+    th, td { padding:14px 18px; text-align:left; border-bottom:1px solid #ccc; }
+    th { background:#fafafa; font-weight:600; }
+    .content-section { width:90%; max-width:1000px; }
   </style>
 </head>
 <body>
-
   <div class="overlay"></div>
+  <div class="lang-toggle"><a href="Startseite.html">DE</a> | <a href="Startseite-en.html">EN</a></div>
+  <button id="menuToggle">&#9776;</button>
+  <nav id="sideMenu">
+    <ul>
+      <li><a href="Startseite.html">Startseite</a></li>
+      <li><a href="Anlegen.html#animalForm">Tier anlegen</a></li>
+      <li><a href="Anlegen.html#genusForm">Gattung anlegen</a></li>
+      <li><a href="Anlegen.html#locationForm">Ort anlegen</a></li>
+      <li><a href="Anlegen.html#observationForm">Beobachtung anlegen</a></li>
+    </ul>
+  </nav>
 
-  <div class="lang-toggle">
-    <a href="Startseite.html">DE</a> | <a href="Startseite-en.html">EN</a>
-  </div>
+  <section id="hero">
+    <div class="content">
+      <h1>WildLifeObservation</h1>
+      <button class="btn" id="weiterButton">Ab in die Wildnis</button>
+    </div>
+  </section>
 
-  <div class="content">
-  <h1>WildLifeObservation</h1>
-  <button class="btn" id="weiterButton">Ab in die Wildnis</button>
-</div>
+  <section id="animalsSection" class="content-section">
+    <h1>Tiere</h1>
+    <table id="animalTable">
+      <thead>
+        <tr><th>ID</th><th>Geschlecht</th><th>Alter</th><th>Gewicht</th><th>Größe</th><th>Gattung</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <section id="genusSection" class="content-section">
+    <h1>Gattungen</h1>
+    <table id="genusTable">
+      <thead>
+        <tr><th>ID</th><th>Bezeichnung</th><th>Lateinische Bezeichnung</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <section id="locationSection" class="content-section">
+    <h1>Orte</h1>
+    <table id="locationTable">
+      <thead>
+        <tr><th>ID</th><th>Kurzbezeichnung</th><th>Beschreibung</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <section id="observationSection" class="content-section">
+    <h1>Beobachtungen</h1>
+    <table id="observedTable">
+      <thead>
+        <tr><th>ID</th><th>Tier ID</th><th>Ort ID</th><th>Datum</th><th>Zeit</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
 <script>
-  document.getElementById("weiterButton").addEventListener("click", function () {
-    document.body.classList.add("blur-effect");
-
-    setTimeout(function () {
-      window.location.href = "Webseite.html";
-    }, 800); // Warten, bis Animation fertig
+const apiBase = 'http://localhost:8080';
+function loadAnimals(){
+  fetch(apiBase + '/animal').then(r=>r.json()).then(data=>{
+    const tb=document.querySelector('#animalTable tbody');
+    tb.innerHTML='';
+    data.forEach(a=>{
+      const genus=a.genus?`${a.genus.designation} (${a.genus.latinDesignation})`:'—';
+      tb.innerHTML+=`<tr><td>${a.id}</td><td>${a.gender}</td><td>${a.estimatedAge}</td><td>${a.estimatedWeight}</td><td>${a.estimatedSize}</td><td>${genus}</td></tr>`;
+    });
   });
+}
+function loadGenus(){
+  fetch(apiBase + '/genus').then(r=>r.json()).then(data=>{
+    const tb=document.querySelector('#genusTable tbody');
+    tb.innerHTML='';
+    data.forEach(g=>{tb.innerHTML+=`<tr><td>${g.id}</td><td>${g.designation}</td><td>${g.latinDesignation}</td></tr>`;});
+  });
+}
+function loadLocations(){
+  fetch(apiBase + '/location').then(r=>r.json()).then(data=>{
+    const tb=document.querySelector('#locationTable tbody');
+    tb.innerHTML='';
+    data.forEach(l=>{tb.innerHTML+=`<tr><td>${l.id}</td><td>${l.shortTitle}</td><td>${l.description}</td></tr>`;});
+  });
+}
+function loadObservations(){
+  fetch(apiBase + '/observed').then(r=>r.json()).then(data=>{
+    const tb=document.querySelector('#observedTable tbody');
+    tb.innerHTML='';
+    data.forEach(o=>{tb.innerHTML+=`<tr><td>${o.id??'-'}</td><td>${o.animalId??'-'}</td><td>${o.locationId??'-'}</td><td>${o.date??'-'}</td><td>${o.time??'-'}</td></tr>`;});
+  });
+}
+loadAnimals();
+loadGenus();
+loadLocations();
+loadObservations();
+
+document.getElementById('weiterButton').addEventListener('click', ()=>{
+  document.getElementById('animalsSection').scrollIntoView({behavior:'smooth'});
+});
+
+const menu=document.getElementById('sideMenu');
+document.getElementById('menuToggle').addEventListener('click',()=>{menu.classList.toggle('open');});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create a new `Anlegen.html` with forms for animals, genus, locations and observations
- extend `Startseite.html` with hamburger menu and lists for all data
- connect start page button to scroll down instead of leaving the page

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68501f8c33ec832c8b3b950693f3c9d2